### PR TITLE
Remove obsolete pivot patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "extra": {
     "patches": {
       "drupal/schema_metatag": {
-        "Allow html in tags (metatag)": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20191023_html-in-tags_schema-metatag.patch",
+        "Allow html in tags (metatag)": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20230313_schema_metatag_html-in-tags.diff",
         "Change pivot element": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20230313_schema_metatag_change_pivot.diff"
       }
     }

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,16 @@
   "type": "drupal-custom-module",
   "require": {
     "drupal/schema_metatag": "~2.4.0"
+  },
+  "extra": {
+    "patches": {
+      "drupal/metatag": {
+        "Allow html in tags (metatag)": "./patches/20200331_html-in-tags_metatag.patch"
+      },
+      "drupal/schema_metatag": {
+        "Allow html in tags (metatag)": "./patches/20191023_html-in-tags_schema-metatag.patch",
+        "Change pivot element": "./patches/20230313_schema_metatag_change_pivot.diff"
+      }
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
   "extra": {
     "patches": {
       "drupal/metatag": {
-        "Allow html in tags (metatag)": "./patches/20200331_html-in-tags_metatag.patch"
+        "Allow html in tags (metatag)": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20200331_html-in-tags_metatag.patch"
       },
       "drupal/schema_metatag": {
-        "Allow html in tags (metatag)": "./patches/20191023_html-in-tags_schema-metatag.patch",
-        "Change pivot element": "./patches/20230313_schema_metatag_change_pivot.diff"
+        "Allow html in tags (metatag)": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20191023_html-in-tags_schema-metatag.patch",
+        "Change pivot element": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20230313_schema_metatag_change_pivot.diff"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
   "description": "Extend the metatag module",
   "type": "drupal-custom-module",
   "require": {
-    "drupal/schema_metatag": "^2.0"
+    "drupal/schema_metatag": "~2.4.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,6 @@
   },
   "extra": {
     "patches": {
-      "drupal/metatag": {
-        "Allow html in tags (metatag)": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20200331_html-in-tags_metatag.patch"
-      },
       "drupal/schema_metatag": {
         "Allow html in tags (metatag)": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20191023_html-in-tags_schema-metatag.patch",
         "Change pivot element": "https://raw.githubusercontent.com/iqual-ch/iq_metatag_extension/issue/US-1234_update_metatags_2.x/patches/20230313_schema_metatag_change_pivot.diff"

--- a/patches/20230313_schema_metatag_change_pivot.diff
+++ b/patches/20230313_schema_metatag_change_pivot.diff
@@ -1,8 +1,8 @@
 diff --git a/src/SchemaMetatagManager.php b/src/SchemaMetatagManager.php
-index 88fa97a..526d32b 100644
+index 6103e84..52d0f98 100644
 --- a/src/SchemaMetatagManager.php
 +++ b/src/SchemaMetatagManager.php
-@@ -169,7 +169,7 @@ class SchemaMetatagManager implements SchemaMetatagManagerInterface {
+@@ -181,7 +181,7 @@ public static function countNumericKeys($item) {
     */
    public static function explode($value) {
      if (is_string($value)) {

--- a/patches/20230313_schema_metatag_html-in-tags.diff
+++ b/patches/20230313_schema_metatag_html-in-tags.diff
@@ -1,0 +1,26 @@
+diff --git a/src/Plugin/metatag/Tag/SchemaNameBase.php b/src/Plugin/metatag/Tag/SchemaNameBase.php
+index e9b9bd8..32e67c7 100644
+--- a/src/Plugin/metatag/Tag/SchemaNameBase.php
++++ b/src/Plugin/metatag/Tag/SchemaNameBase.php
+@@ -272,7 +272,7 @@ protected function processItem(&$value, $key = 0) {
+     $value = $this->parseImageUrlValue($value, $explode);
+ 
+     // Convert value to plain text.
+-    $value = PlainTextOutput::renderFromHtml($value);
++    // $value = PlainTextOutput::renderFromHtml($value);
+ 
+     // Trim resulting plain text value.
+     $value = trim($value);
+diff --git a/src/SchemaMetatagManager.php b/src/SchemaMetatagManager.php
+index 6103e84..205d056 100644
+--- a/src/SchemaMetatagManager.php
++++ b/src/SchemaMetatagManager.php
+@@ -57,7 +57,7 @@ public static function encodeJsonld(array $items) {
+     // If some group has been found, render the JSON LD,
+     // otherwise return nothing.
+     if (!empty($items)) {
+-      return json_encode($items, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE);
++      return json_encode($items, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
+     }
+     else {
+       return '';

--- a/patches/composer.patches.json
+++ b/patches/composer.patches.json
@@ -4,7 +4,8 @@
       "Allow html in tags (metatag)": "/var/www/patches/20200331_html-in-tags_metatag.patch"
     },
     "drupal/schema_metatag": {
-      "Allow html in tags (metatag)": "/var/www/patches/20191023_html-in-tags_schema-metatag.patch"
+      "Allow html in tags (metatag)": "/var/www/patches/20191023_html-in-tags_schema-metatag.patch",
+      "Change pivot element": "/var/www/patches/20230313_schema_metatag_change_pivot.diff"
     }
   }
 }

--- a/patches/composer.patches.json
+++ b/patches/composer.patches.json
@@ -4,8 +4,7 @@
       "Allow html in tags (metatag)": "/var/www/patches/20200331_html-in-tags_metatag.patch"
     },
     "drupal/schema_metatag": {
-      "Allow html in tags (metatag)": "/var/www/patches/20191023_html-in-tags_schema-metatag.patch",
-      "Change pivot string to ::": "/var/www/patches/20211029_change-pivot_schema-metatag.patch"
+      "Allow html in tags (metatag)": "/var/www/patches/20191023_html-in-tags_schema-metatag.patch"
     }
   }
 }


### PR DESCRIPTION
- Updates the module to use drupal/schema_metatag:2.4 to be compatible with Drupal10

Open tasks:

- [ ] Test application of the patches -> BK
- [ ] Test whether behavior is still the same as before -> DW/KL